### PR TITLE
Fix twitter url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: rebase-conf
 url: "rebase-conf.org" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: rebase-conf
+twitter_username: rebase_conf
 github_username:  rebase-conf
 
 # Build settings


### PR DESCRIPTION
So the main twitter link people would normally see is correct. But I happened to accidentally discover this one by seeing if https://rebase-conf.org/2019/ was a url. At the bottom you will see the incorrect link. I doubt many people will do what I did, but figured I'd fix it anyways.